### PR TITLE
Parametrize dlopen feature names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,5 @@ authors = ["Victor Berger <victor.berger@m4x.org>"]
 license = "MIT"
 description = "Helper macros for handling manually loading optional system libraries."
 
-
 [dependencies]
 libloading = "0.6"
-
-[features]
-dlopen = []

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ can or cannot be optionally loaded at runtime, depending on whether a certain fe
 dlib defines the `external_library!` macro, which can be invoked in this way:
 
 ```rust
-external_library!("dlopen-foo", Foo, "foo",
+external_library!(feature="dlopen-foo", Foo, "foo",
     statics:
         me: c_int,
         you: c_float,
@@ -29,7 +29,7 @@ As you can see, it is required to separate static values from functions and from
 having variadic arguments. Each of these 3 categories is optional, but the ones used must appear
 in this order. Return types of the functions must all be explicit (hence `-> ()` for void functions).
 
-If the feature named by the first argument (in this example, `dlopen-foo`) is absent on your crate,
+If the feature named by the `feature` argument (in this example, `dlopen-foo`) is absent on your crate,
 this macro will expand to an extern block defining each of the items, using the third argument
 of the macro as a link name:
 
@@ -47,8 +47,8 @@ extern "C" {
 
 ```
 
-If the feature named by the first argument is present on your crate, it will expand to a `struct`
-named by the second argument of the macro, with one field for each of the symbols defined;
+If the feature named by the `feature` argument is present on your crate, it will expand to a
+`struct` named by the second argument of the macro, with one field for each of the symbols defined;
 and a method `open`, which tries to load the library from the name or path given as an argument.
 
 ```rust
@@ -88,10 +88,10 @@ dlib = "0.5"
 dlopen-foo = []
 ```
 
-Then give the name of that feature as the first argument to dlib's macros:
+Then give the name of that feature as the `feature` argument to dlib's macros:
 
 ```rust
-external_library!("dlopen-foo", Foo, "foo",
+external_library!(feature="dlopen-foo", Foo, "foo",
     functions:
         fn foo() -> c_int,
 );
@@ -100,8 +100,8 @@ external_library!("dlopen-foo", Foo, "foo",
 `dlib` provides helper macros to dispatch the access to foreign symbols:
 
 ```rust
-ffi_dispatch!("dlopen-foo", Foo, function, arg1, arg2);
-ffi_dispatch_static!("dlopen-foo", Foo, my_static_var);
+ffi_dispatch!(feature="dlopen-foo", Foo, function, arg1, arg2);
+ffi_dispatch_static!(feature="dlopen-foo", Foo, my_static_var);
 ```
 
 These will expand to the appropriate value or function call depending on the presence or absence of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,12 +128,12 @@ macro_rules! dlopen_external_library(
         $(functions: $(fn $fname: ident($($farg: ty),*) -> $fret:ty),+,)|*
         $(varargs: $(fn $vname: ident($($vargs: ty),+) -> $vret: ty),+,)|*
     ) => (
-        dlopen_external_library!(__struct,
+        $crate::dlopen_external_library!(__struct,
             $structname, $(statics: $($sname: $stype),+,)|*
             $(functions: $(fn $fname($($farg),*) -> $fret),+,)|*
             $(varargs: $(fn $vname($($vargs),+) -> $vret),+,)|*
         );
-        dlopen_external_library!(__impl,
+        $crate::dlopen_external_library!(__impl,
             $structname, $(statics: $($sname: $stype),+,)|*
             $(functions: $(fn $fname($($farg),*) -> $fret),+,)|*
             $(varargs: $(fn $vname($($vargs),+) -> $vret),+,)|*
@@ -150,14 +150,14 @@ macro_rules! external_library(
         $(varargs: $(fn $vname: ident($($vargs: ty),+) -> $vret: ty),+,)|*
     ) => (
         #[cfg(feature = $feature)]
-        dlopen_external_library!(
+        $crate::dlopen_external_library!(
             $structname, $(statics: $($sname: $stype),+,)|*
             $(functions: $(fn $fname($($farg),*) -> $fret),+,)|*
             $(varargs: $(fn $vname($($vargs),+) -> $vret),+,)|*
         );
 
         #[cfg(not(feature = $feature))]
-        link_external_library!(
+        $crate::link_external_library!(
             $link, $(statics: $($sname: $stype),+,)|*
             $(functions: $(fn $fname($($farg),*) -> $fret),+,)|*
             $(varargs: $(fn $vname($($vargs),+) -> $vret),+,)|*


### PR DESCRIPTION
This PR adds an argument to the beginning of dlib's macros which specifies the name of the feature that switches between dlopen and linking the library at build time. In this branch, the specified feature lives on the crate using dlib, which means crates no longer have to enable the `dlopen` feature on dlib. For example, in this snippet, the library is linked at build time if the `dlopen-foo` feature is disabled on the crate it resides in:

```rust
external_library!("dlopen-foo", Foo, "foo",
    functions:
        fn foo() -> c_int,
);
```

See the [README](https://github.com/milkey-mouse/dlib/blob/parametrized-feature-name/README.md) for more information, and also Smithay/client-toolkit#178 for context.