### PR TITLE
Allow attributes in macro invocations 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ['1.40.0', 'stable', 'beta']
+        rust: ['1.56.0', 'stable', 'beta']
       
     runs-on: ubuntu-latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ exclude = ["/dlib-test", "README.tpl"]
 readme = "README.md"
 keywords = ["dylib", "dlopen"]
 categories = ["api-bindings"]
+edition = "2021"
 
 [dependencies]
 libloading = ">=0.7, <0.9"

--- a/dlib-test/Cargo.toml
+++ b/dlib-test/Cargo.toml
@@ -10,4 +10,7 @@ dlib = { path = "../" }
 lazy_static = { version = "1.0", optional = true }
 
 [features]
-"dlopen" = ["lazy_static"]
+default = ["sin"]
+sin = []
+nonexistant = []
+dlopen = ["lazy_static"]

--- a/dlib-test/src/lib.rs
+++ b/dlib-test/src/lib.rs
@@ -3,6 +3,10 @@ use dlib::external_library;
 external_library!(Mlib, "m",
     functions:
         fn cos(f64) -> f64,
+        #[cfg(feature = "sin")]
+        fn sin(f64) -> f64,
+        #[cfg(feature = "nonexistant")]
+        fn nonexistant_function(f64) -> f64,
 );
 
 #[cfg(feature = "dlopen")]
@@ -20,5 +24,14 @@ mod tests {
         let angle = 1.8;
         let cosinus = unsafe { ffi_dispatch!(M_STATIC, cos, angle) };
         assert_eq!(cosinus, angle.cos());
+
+    }
+
+    #[cfg(feature = "sin")]
+    #[test]
+    fn invoke_sin() {
+        let angle = 1.8;
+        let sine = unsafe { ffi_dispatch!(M_STATIC, sin, angle) };
+        assert_eq!(sine, angle.sin());
     }
 }

--- a/dlib-test/src/lib.rs
+++ b/dlib-test/src/lib.rs
@@ -1,12 +1,22 @@
 use dlib::external_library;
 
 external_library!(Mlib, "m",
+    /* TODO: local ambiguity when calling macro
+    statics:
+        #[cfg(feature = "nonexistant")]
+        non_existant_static: f64,
+    */
     functions:
         fn cos(f64) -> f64,
         #[cfg(feature = "sin")]
         fn sin(f64) -> f64,
         #[cfg(feature = "nonexistant")]
         fn nonexistant_function(f64) -> f64,
+    /* TODO: no rules expected this token in macro call
+    varargs:
+        #[cfg(feature = "nonexistant")]
+        fn nonexistant_varargs(f64 ...) -> f64,
+    */
 );
 
 #[cfg(feature = "dlopen")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 //! dlib defines the `external_library!` macro, which can be invoked in this way:
 //!
 //! ```rust
+//! # use dlib::external_library;
+//! # use std::ffi::{c_float, c_int};
 //! external_library!(feature="dlopen-foo", Foo, "foo",
 //!     statics:
 //!         me: c_int,
@@ -28,7 +30,8 @@
 //! this macro will expand to an extern block defining each of the items, using the third argument
 //! of the macro as a link name:
 //!
-//! ```rust
+//! ```rust no_run
+//! # use std::ffi::{c_float, c_int, c_void};
 //! #[link(name = "foo")]
 //! extern "C" {
 //!     pub static me: c_int;
@@ -47,6 +50,8 @@
 //! and a method `open`, which tries to load the library from the name or path given as an argument.
 //!
 //! ```rust
+//! # use dlib::DlError;
+//! # use std::ffi::{c_float, c_int, c_void};
 //! pub struct Foo {
 //!     pub me: &'static c_int,
 //!     pub you: &'static c_float,
@@ -59,7 +64,10 @@
 //!
 //!
 //! impl Foo {
-//!     pub unsafe fn open(name: &str) -> Result<Foo, DlError> { /* ... */ }
+//!     pub unsafe fn open(name: &str) -> Result<Foo, DlError> {
+//!         /* ... */
+//!         # todo!()
+//!     }
 //! }
 //! ```
 //!
@@ -90,7 +98,9 @@
 //!
 //! Then give the name of that feature as the `feature` argument to dlib's macros:
 //!
-//! ```rust
+//! ```rust no_run
+//! # use dlib::external_library;
+//! # use std::ffi::c_int;
 //! external_library!(feature="dlopen-foo", Foo, "foo",
 //!     functions:
 //!         fn foo() -> c_int,
@@ -99,7 +109,12 @@
 //!
 //! `dlib` provides helper macros to dispatch the access to foreign symbols:
 //!
-//! ```rust
+//! ```rust no_run
+//! # use dlib::{ffi_dispatch, ffi_dispatch_static};
+//! # let arg1 = todo!();
+//! # let arg2 = todo!();
+//! # let function: fn(u32, u32) = todo!();
+//! # let my_static_var = todo!();
 //! ffi_dispatch!(feature="dlopen-foo", Foo, function, arg1, arg2);
 //! ffi_dispatch_static!(feature="dlopen-foo", Foo, my_static_var);
 //! ```
@@ -122,6 +137,8 @@
 //! Then, it can become as simple as putting this on top of all modules using the FFI:
 //!
 //! ```rust
+//! # #![allow(unexpected_cfgs)]
+//! # mod ffi {}
 //! #[cfg(feature = "dlopen-foo")]
 //! use ffi::FOO_STATIC;
 //! #[cfg(not(feature = "dlopen-foo"))]


### PR DESCRIPTION
Allows `#[cfg]` to be used to make certain definitions conditional. Such as for library version feature flags.

Needed for https://github.com/Smithay/wayland-rs/pull/735 so it can have a feature flag for the libwayland version.

Seems to work, but still needs to be added to `dlib-test`, with CI to test with and without the feature.