### PR TITLE
make crate `#![no_std]` friendly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,8 @@ keywords = ["dylib", "dlopen"]
 categories = ["api-bindings"]
 
 [dependencies]
-libloading = ">=0.7, <0.9"
+libloading = { version = ">=0.7, <0.9", optional = true }
+
+[features]
+default = [ "std" ]
+std = [ "dep:libloading" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@
 //! #[cfg(not(feature = "dlopen-foo"))]
 //! use ffi::*;
 //! ```
+#![no_std]
 #![warn(missing_docs)]
 
 extern crate libloading;
@@ -240,8 +241,8 @@ pub enum DlError {
     MissingSymbol(&'static str),
 }
 
-impl std::error::Error for DlError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for DlError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match *self {
             DlError::CantOpen(ref e) => Some(e),
             DlError::MissingSymbol(_) => None,
@@ -249,8 +250,8 @@ impl std::error::Error for DlError {
     }
 }
 
-impl std::fmt::Display for DlError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for DlError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) ->core::fmt::Result {
         match *self {
             DlError::CantOpen(ref e) => write!(f, "Could not open the requested library: {}", e),
             DlError::MissingSymbol(s) => write!(f, "The requested symbol was missing: {}", s),
@@ -287,7 +288,7 @@ macro_rules! dlopen_external_library(
     impl $structname {
         pub unsafe fn open(name: &str) -> Result<$structname, $crate::DlError> {
             // we use it to ensure the 'static lifetime
-            use std::mem::transmute;
+            use core::mem::transmute;
             let lib = $crate::Library::new(name).map_err($crate::DlError::CantOpen)?;
             let s = $structname {
                 $($($sname: {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,12 @@
 //! #[cfg(not(feature = "dlopen-foo"))]
 //! use ffi::*;
 //! ```
+//!
+//! ## A note on `#![no_std]` support
+//!
+//! Deactivating the `std` dependency through `default-features = false` will stop `dlib` from
+//! importing `libloading`. This means in `no_std` environments, users of this library *must*
+//! link their binaries, and not use `dlopen`.
 #![no_std]
 #![warn(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,10 +130,14 @@
 #![no_std]
 #![warn(missing_docs)]
 
+#[cfg(feature = "std")]
 extern crate libloading;
 
+#[cfg(feature = "std")]
 pub use libloading::Error as LibLoadingError;
+
 #[doc(hidden)]
+#[cfg(feature = "std")]
 pub use libloading::{Library, Symbol};
 
 /// Macro for generically invoking a FFI function
@@ -236,6 +240,7 @@ pub enum DlError {
     ///
     /// Includes the error reported by `libloading` when trying to
     /// open the library.
+    #[cfg(feature = "std")]
     CantOpen(LibLoadingError),
     /// Some required symbol was missing in the library
     MissingSymbol(&'static str),
@@ -244,6 +249,7 @@ pub enum DlError {
 impl core::error::Error for DlError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match *self {
+            #[cfg(feature = "std")]
             DlError::CantOpen(ref e) => Some(e),
             DlError::MissingSymbol(_) => None,
         }
@@ -251,8 +257,9 @@ impl core::error::Error for DlError {
 }
 
 impl core::fmt::Display for DlError {
-    fn fmt(&self, f: &mut core::fmt::Formatter) ->core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match *self {
+            #[cfg(feature = "std")]
             DlError::CantOpen(ref e) => write!(f, "Could not open the requested library: {}", e),
             DlError::MissingSymbol(s) => write!(f, "The requested symbol was missing: {}", s),
         }


### PR DESCRIPTION
We can make the crate work in `#![no_std]` environments with minimal changes. Literally just changing a few imports.

Should be trivial to maintain as well, just make sure to always import from `core` rather than `std`. I could maybe try adding a `no_std` test to make sure the codegen always compiles in `no_std` environments, if necessary.