### PR TITLE
breaking: Update `libloading` to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-libloading = ">=0.7, <0.9"
+libloading = "0.9"
 
 [workspace]
 members = [


### PR DESCRIPTION
This is a breaking API change since `libloading::Symbol` is used in the bindings generated by `dlib`. Maybe it would be best to avoid that... (is `wayland-sys` a public dep of `wayland-backend`, or can we bump it's version without bumping the rest of wayland-rs?)